### PR TITLE
Limit URO size to 256KB

### DIFF
--- a/udp-rsc-offload.md
+++ b/udp-rsc-offload.md
@@ -48,7 +48,8 @@ URO indications should set the IP length, IPv4 checksum, UDP length, and UDP che
 
 If L2 headers are present in coalesced datagrams, the SCU must contain a valid L2 header. The contents of the L2 header in each coalesced datagram may vary; the L2 header in the SCU should resemble the L2 header of at least one of the coalesced datagrams.
 
-The full SCU size (max of 0xFFFFFFFF) must be set in the NB->DataLength field.
+The full SCU size must be set in the NB->DataLength field. The size of SCUs should not exceed 2MB.
+
 ```
 +------------------------------------------------------------------------------------------+
 | L2 Header | IP Header | UDP Header | UDP Payload 1 | UDP Payload 2 | ... | UDP Payload N |

--- a/udp-rsc-offload.md
+++ b/udp-rsc-offload.md
@@ -48,7 +48,7 @@ URO indications should set the IP length, IPv4 checksum, UDP length, and UDP che
 
 If L2 headers are present in coalesced datagrams, the SCU must contain a valid L2 header. The contents of the L2 header in each coalesced datagram may vary; the L2 header in the SCU should resemble the L2 header of at least one of the coalesced datagrams.
 
-The full SCU size must be set in the NB->DataLength field. The size of SCUs should not exceed 2MB.
+The full SCU size must be set in the NB->DataLength field. The size of SCUs should not exceed 256KB.
 
 ```
 +------------------------------------------------------------------------------------------+


### PR DESCRIPTION
LSO and USO allow TX packets to exceed the max IP payload, but allow NICs to impose their own constraints on the max size. In practice, these max sizes are usually around 64KB.

We should impose a similar URO limit to allow components on the receive path to optimize for known max packet sizes, e.g. by creating a set of buffer pools of increasing size, up to a limit. Today that limit in Windows is often 64KB.

There will be diminishing returns on coalescing long before ~~2MB~~ 256KB, so setting a reasonable limit should improve perf.